### PR TITLE
Fixed deepcopy()-ing PermanentQuerySet

### DIFF
--- a/django_permanent/query.py
+++ b/django_permanent/query.py
@@ -1,3 +1,4 @@
+import copy
 from functools import partial
 
 from django.db.models.query import QuerySet, ValuesQuerySet
@@ -9,6 +10,15 @@ from django_permanent import settings
 
 
 class PermanentQuerySet(QuerySet):
+    def __deepcopy__(self, memo):
+        obj = self.__class__(model=self.model)
+        for k, v in self.__dict__.items():
+            if k == '_result_cache':
+                obj.__dict__[k] = None
+            else:
+                obj.__dict__[k] = copy.deepcopy(v, memo)
+        return obj
+
     def create(self, **kwargs):
         if self.model.Permanent.restore_on_create and not kwargs.get(settings.FIELD):
             qs = self.get_unpatched()


### PR DESCRIPTION
Fixed `deepcopy()`-ing `PermanentQuerySet` by overriding `__deepcopy__()` and passing `model=self.model` to constructor.

This fix looks rather hacky, but there's no cleaner way to override `QuerySet.__deepcopy__()`, and I think the only other solution would be to completely move the logic in `NonDeletedQuerySet.__init__()` and `DeletedQuerySet.__init__()` to another method, which might break compatibility for other users.

This change is required for django-permanent to work with Django REST Framework 3.x.

Thanks for the great lib and hard work!
~Y
