### PR TITLE
Replaced import_by_path with import_string for Django 1.8 compatibility

### DIFF
--- a/django_permanent/models.py
+++ b/django_permanent/models.py
@@ -1,5 +1,5 @@
 from django.db import models, router
-from django.utils.module_loading import import_by_path
+from django.utils.module_loading import import_string
 
 from django_permanent import settings
 from .deletion import *  # NOQA
@@ -40,5 +40,5 @@ class PermanentModel(models.Model):
         post_restore.send(sender=self.__class__, instance=self)
 
 
-field = import_by_path(settings.FIELD_CLASS)
+field = import_string(settings.FIELD_CLASS)
 PermanentModel.add_to_class(settings.FIELD, field(**settings.FIELD_KWARGS))


### PR DESCRIPTION
Just a small change to remove the warning on Django 1.8
