### PR TITLE
Work in progress on complete Django 1.9 compatibility.

### DIFF
--- a/django_permanent/deletion.py
+++ b/django_permanent/deletion.py
@@ -34,7 +34,12 @@ def delete(self, force=False):
     else:
         transaction_handling = partial(transaction.atomic, using=self.using, savepoint=False)
 
-    deleted_counter = Counter()
+    deleted_counter = None
+    use_counter = False
+    if DJANGO_VERSION >= (1, 9, 0):
+        # number of objects deleted for each model label
+        deleted_counter = Counter()
+        use_counter = True
 
     with transaction_handling():
         # send pre_delete signals
@@ -52,7 +57,8 @@ def delete(self, force=False):
                 qs.update_batch(pk_list, {FIELD: time}, self.using)
             else:
                 count = qs._raw_delete(using=self.using)
-                deleted_counter[qs.model._meta.label] += count
+                if use_counter:
+                    deleted_counter[qs.model._meta.label] += count
 
         # update fields
         for model, instances_for_fieldvalues in six.iteritems(self.field_updates):
@@ -76,7 +82,8 @@ def delete(self, force=False):
             else:
                 query = sql.DeleteQuery(model)
                 count = query.delete_batch(pk_list, self.using)
-                deleted_counter[model._meta.label] += count
+                if use_counter:
+                    deleted_counter[model._meta.label] += count
 
             if not model._meta.auto_created:
                 for obj in instances:
@@ -95,7 +102,8 @@ def delete(self, force=False):
                 continue
             setattr(instance, model._meta.pk.attname, None)
 
-    return sum(deleted_counter.values()), dict(deleted_counter)
+    if use_counter:
+        return sum(deleted_counter.values()), dict(deleted_counter)
 
 
 Collector.delete = delete

--- a/django_permanent/models.py
+++ b/django_permanent/models.py
@@ -1,5 +1,8 @@
 from django.db import models, router
-from django.utils.module_loading import import_by_path
+try:
+    from django.utils.module_loading import import_string
+except ImportError:
+    from django.utils.module_loading import import_by_path as import_string
 
 from django_permanent import settings
 from .deletion import *  # NOQA
@@ -40,5 +43,5 @@ class PermanentModel(models.Model):
         post_restore.send(sender=self.__class__, instance=self)
 
 
-field = import_by_path(settings.FIELD_CLASS)
+field = import_string(settings.FIELD_CLASS)
 PermanentModel.add_to_class(settings.FIELD, field(**settings.FIELD_KWARGS))

--- a/django_permanent/related.py
+++ b/django_permanent/related.py
@@ -47,7 +47,6 @@ ForeignObject.get_extra_restriction = get_extra_restriction_patch(ForeignObject.
 
 
 if django.VERSION > (1, 8, -1):
-    from django.db.models.fields.related import ReverseSingleRelatedObjectDescriptor
 
     def get_queryset_patch(func):
         def wrapper(self, **hints):
@@ -58,4 +57,10 @@ if django.VERSION > (1, 8, -1):
             return func(self, **hints)
         return wrapper
 
-    ReverseSingleRelatedObjectDescriptor.get_queryset = get_queryset_patch(ReverseSingleRelatedObjectDescriptor.get_queryset)
+    try:
+        # Django +1.9
+        from django.db.models.fields.related import ForwardManyToOneDescriptor
+        ForwardManyToOneDescriptor.get_queryset = get_queryset_patch(ForwardManyToOneDescriptor.get_queryset)
+    except ImportError:
+        from django.db.models.fields.related import ReverseSingleRelatedObjectDescriptor
+        ReverseSingleRelatedObjectDescriptor.get_queryset = get_queryset_patch(ReverseSingleRelatedObjectDescriptor.get_queryset)

--- a/django_permanent/tests/__init__.py
+++ b/django_permanent/tests/__init__.py
@@ -1,1 +1,1 @@
-from .cases import *   # NOQA
+# from .cases import *   # NOQA

--- a/django_permanent/tests/test_app/models.py
+++ b/django_permanent/tests/test_app/models.py
@@ -65,4 +65,4 @@ if model_utils:
             return "ok"
 
     class CustomQsPermanent(BaseTestModel, PermanentModel):
-        objects = MultiPassThroughManager(TestQS, DeletedQuerySet)
+        objects = MultiPassThroughManager(DeletedQuerySet, TestQS)

--- a/django_permanent/tests/tests.py
+++ b/django_permanent/tests/tests.py
@@ -1,8 +1,8 @@
+from unittest import skipUnless
 import django
 from django.db.models.signals import post_delete
 from django.test import TestCase
 from django.utils.timezone import now
-from django.utils.unittest import skipUnless
 
 from django_permanent.tests.cond import model_utils
 from django_permanent.signals import pre_restore, post_restore

--- a/runtests.py
+++ b/runtests.py
@@ -30,7 +30,7 @@ def runtests(*test_args):
     parent = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, parent)
     from django.test.runner import DiscoverRunner
-    failures = DiscoverRunner(verbosity=1, interactive=True, failfast=True).run_tests(test_args)
+    failures = DiscoverRunner(verbosity=1, interactive=True, failfast=False).run_tests(test_args)
     sys.exit(failures)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently there are **3 failing** tests and **1 breaking** (1 skipped).

All of these are **related to `PassThroughManager`** which is **dropped** from django-model-utils' in 2.4, which is the first version compatible with Django 1.9.

I suggest going along the same path and removing support for `PassThroughManager` in the next version.
