### PR TITLE
All objects bug - need check if self.field.remote_field.model has `all_objects` attribute

### DIFF
--- a/django_permanent/related.py
+++ b/django_permanent/related.py
@@ -62,12 +62,12 @@ if django.VERSION > (1, 8, -1):
             instance = hints.get('instance')
             if instance and isinstance(instance, PermanentModel) and getattr(instance, settings.FIELD):
                 if django.VERSION < (1, 9, 0):
-                    return self.field.rel.to.all_objects
+                    model = self.field.rel.to
                 else:
                     model = self.field.remote_field.model
-                    if hasattr(model, 'all_objects'):
-                        return model.all_objects
-                    return model.objects
+                if hasattr(model, 'all_objects'):
+                    return model.all_objects
+                return model.objects
             return func(self, **hints)
         return wrapper
 

--- a/django_permanent/related.py
+++ b/django_permanent/related.py
@@ -64,7 +64,10 @@ if django.VERSION > (1, 8, -1):
                 if django.VERSION < (1, 9, 0):
                     return self.field.rel.to.all_objects
                 else:
-                    return self.field.remote_field.model.all_objects
+                    model = self.field.remote_field.model
+                    if hasattr(model, 'all_objects'):
+                        return model.all_objects
+                    return model.objects
             return func(self, **hints)
         return wrapper
 

--- a/django_permanent/tests/cases.py
+++ b/django_permanent/tests/cases.py
@@ -7,6 +7,7 @@ from django.db.models.signals import post_delete
 from django.test import TestCase
 from django.utils.timezone import now
 
+from django_permanent.tests.test_app.models import RegularModel, RemovableRegularDepended
 from .test_app.models import (
     CustomQsPermanent,
     M2MFrom,
@@ -61,6 +62,15 @@ class TestDelete(TestCase):
         self.permanent.delete()
         depended = model.objects.first()
         self.assertEqual(depended.dependence, None)
+
+    def test_remove_removable_nullable_depended(self):
+        model = RemovableRegularDepended
+        test_model = model.objects.create(dependence=RegularModel.objects.create(name='Test'))
+        test_model.delete()
+        try:
+            self.assertIsNotNone(model.deleted_objects.first().dependence)
+        except AttributeError:
+            self.fail()
 
     def test_permanent_depended(self):
         model = PermanentDepended

--- a/django_permanent/tests/test_app/models.py
+++ b/django_permanent/tests/test_app/models.py
@@ -19,6 +19,15 @@ class MyPermanentModel(PermanentModel, BaseTestModel):
     pass
 
 
+class RegularModel(BaseTestModel):
+    name = models.CharField(max_length=255, blank=True, null=True)
+    pass
+
+
+class RemovableRegularDepended(PermanentModel, BaseTestModel):
+    dependence = models.ForeignKey(RegularModel, on_delete=models.CASCADE)
+
+
 class RemovableDepended(BaseTestModel):
     dependence = models.ForeignKey(MyPermanentModel, on_delete=models.CASCADE)
 


### PR DESCRIPTION
I'm sorry that it took so long but I had some problems with reproducing it, but i have finally made it. 

Traceback with bug 

```
======================================================================
ERROR: test_remove_removable_nullable_depended (django_permanent.tests.cases.TestDelete)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "lib\site-packages\django\db\models\fields\related_descriptors.py", line 170, in __get__
    rel_obj = getattr(instance, self.cache_name)
AttributeError: 'RemovableRegularDepended' object has no attribute '_dependence_cache'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "django-permanent\django_permanent\tests\cases.py", line 70, in test_remove_removable_nullable_depended
    self.assertIsNotNone(model.deleted_objects.first().dependence)
  File "lib\site-packages\django\db\models\fields\related_descriptors.py", line 176, in __get__
    qs = self.get_queryset(instance=instance)
  File "django-permanent\django_permanent\related.py", line 67, in wrapper
    return self.field.remote_field.model.all_objects
AttributeError: type object 'RegularModel' has no attribute 'all_objects'

----------------------------------------------------------------------
Ran 23 tests in 0.062s

FAILED (errors=1)
```

