### PR TITLE
README: Improved description of how Permanent.restore_on_create works.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ If you need to restore a deleted object instead of re-creating the same one use 
         class Permanent:
           restore_on_create = True
 
-In this case ``QuerySet`` provides check existence of same attribute objects and restores them if they've been deleted, creating new ones if not.
+In this case, ``MyModel.objects.create(...)`` checks for the existence of a soft-deleted object with the same attributes, restoring it if it exists, creating a new one if not. Note that this does not work when creating a new object with ``my_model.save()``.
 
 Managers
 ========


### PR DESCRIPTION
I had to view the code to figure out how get Permanent.restore_on_create working. Then I also had to update my code, which was using my_model.save() instead of MyModel.objects.create() - which is fine, but it should be mentioned clearly in the documentation. This pull request addresses that issue by updating the README file.