### PR TITLE
Pass extra force parameter to pre_delete and post_delete signals

### DIFF
--- a/django_permanent/deletion.py
+++ b/django_permanent/deletion.py
@@ -42,7 +42,7 @@ def delete(self, force=False):
         for model, obj in self.instances_with_model():
             if not model._meta.auto_created:
                 signals.pre_delete.send(
-                    sender=model, instance=obj, using=self.using
+                    sender=model, instance=obj, using=self.using, force=force
                 )
 
         # fast deletes
@@ -88,7 +88,7 @@ def delete(self, force=False):
             if not model._meta.auto_created:
                 for obj in instances:
                     signals.post_delete.send(
-                        sender=model, instance=obj, using=self.using
+                        sender=model, instance=obj, using=self.using, force=force
                     )
 
     # update collected instances


### PR DESCRIPTION
For some use cases, it is good to know which type of deletion is going to happen.
Moreover, all signal handlers have to take `**kwargs`, so extra argument won't break existing code.